### PR TITLE
chore: Add hera notebook forecast example

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -51,6 +51,7 @@
         "pyzmq",
         "stdenv",
         "demisto",
-        "toomanyrequests"
+        "toomanyrequests",
+        "envrc"
     ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -42,6 +42,15 @@
         "getcwd",
         "isdir",
         "kernelspec",
-        "nbformat"
+        "nbformat",
+        "direnv",
+        "dlopen",
+        "libstdc",
+        "nixpkgs",
+        "pkgs",
+        "pyzmq",
+        "stdenv",
+        "demisto",
+        "toomanyrequests"
     ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -24,6 +24,19 @@
         "listdir",
         "markdownlint",
         "spilts",
-        "tmpl"
+        "tmpl",
+        "dataplatform",
+        "pandas",
+        "numpy",
+        "Jupyter",
+        "ipynb",
+        "ipykernel",
+        "venv",
+        "polyfit",
+        "intraday",
+        "groupby",
+        "Midlands",
+        "mwh",
+        "vsc"
     ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -37,6 +37,11 @@
         "groupby",
         "Midlands",
         "mwh",
-        "vsc"
+        "vsc",
+        "amancevice",
+        "getcwd",
+        "isdir",
+        "kernelspec",
+        "nbformat"
     ]
 }

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use nix
+PATH_add .venv/bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.gitnexus

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __pycache__
 .gitnexus
+
+# Python virtualenv and direnv state (never committed).
+.venv/
+.direnv/

--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ You are encouraged to fork the repo and experiment with adjusting the workflows 
 
 ## Examples
 
-| Example Name                                             | Description                                                                                                                                |
-|----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| [cronworkflow-example]( examples/cronworkflow-example/ ) | Runs a basic CronWorkflow.                                                                                                                 |
-| [dag-diamond]( examples/dag-diamond/ )                   | Runs a basic DAG Workflow.                                                                                                                 |
-| [external-logs]( examples/external-logs/ )               | Workflows deploys a kubernetes job. You can see the logs from the job within Pipekit.                                                      |
-| [fan-out-fan-in]( examples/fan-out-fan-in/ )             | Shows how S3 artifact processing can be parallelized with Argo Workflows using a fan-out approach.                                         |
-| [get-versions](examples/get-versions/)                   | A workflow that outputs the versions of software installed in a Pipekit free trial cluster. Available as both a Hera and a native Workflow |
-| [hera-coinflip](examples/hera-coinflip/)                 | Runs a basic coinflip example using the Hera Python framework.                                                                             |
-| [hera-notebook-forecast](examples/hera-notebook-forecast/) | Press-play data job from a Jupyter notebook: aggregate energy demand and forecast the next day with Hera. Shows a platform-team abstraction that hides Kubernetes. |
-|                                                          |                                                                                                                                            |
+| Example Name                                               | Description                                                                                                                                |
+|------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| [cronworkflow-example]( examples/cronworkflow-example/ )   | Runs a basic CronWorkflow.                                                                                                                 |
+| [dag-diamond]( examples/dag-diamond/ )                     | Runs a basic DAG Workflow.                                                                                                                 |
+| [external-logs]( examples/external-logs/ )                 | Workflows deploys a kubernetes job. You can see the logs from the job within Pipekit.                                                      |
+| [fan-out-fan-in]( examples/fan-out-fan-in/ )               | Shows how S3 artifact processing can be parallelized with Argo Workflows using a fan-out approach.                                         |
+| [get-versions](examples/get-versions/)                     | A workflow that outputs the versions of software installed in a Pipekit free trial cluster. Available as both a Hera and a native Workflow |
+| [hera-coinflip](examples/hera-coinflip/)                   | Runs a basic coinflip example using the Hera Python framework.                                                                             |
+| [hera-notebook-forecast](examples/hera-notebook-forecast/) | Press-play data job from a Jupyter notebook: aggregate energy demand and forecast the next day. Shows a platform abstraction over Hera.    |

--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ You are encouraged to fork the repo and experiment with adjusting the workflows 
 | [fan-out-fan-in]( examples/fan-out-fan-in/ )             | Shows how S3 artifact processing can be parallelized with Argo Workflows using a fan-out approach.                                         |
 | [get-versions](examples/get-versions/)                   | A workflow that outputs the versions of software installed in a Pipekit free trial cluster. Available as both a Hera and a native Workflow |
 | [hera-coinflip](examples/hera-coinflip/)                 | Runs a basic coinflip example using the Hera Python framework.                                                                             |
+| [hera-notebook-forecast](examples/hera-notebook-forecast/) | Press-play data job from a Jupyter notebook: aggregate energy demand and forecast the next day with Hera. Shows a platform-team abstraction that hides Kubernetes. |
 |                                                          |                                                                                                                                            |

--- a/examples/hera-notebook-forecast/README.md
+++ b/examples/hera-notebook-forecast/README.md
@@ -1,0 +1,61 @@
+[![Pipekit Logo](../../assets/images/pipekit-logo.png)](https://pipekit.io)
+
+# Hera Notebook Forecast
+
+A notebook-driven data job for analysts. Press play in a Jupyter notebook to run a real workflow on Pipekit, with Kubernetes hidden.
+
+The job is an energy demand forecast: it generates synthetic half-hourly demand readings for a few regions, aggregates them into daily energy totals (MWh), and fits a linear trend to forecast the next day. The job is generic, so you can swap in your own logic.
+
+This example splits the work the way a platform team would:
+
+- `dataplatform/`: the platform team's library. It sets the image, resource requests, service account, namespace, cluster, and the Pipekit connection. Analysts never touch it.
+- `forecast_step.py`: the single Hera `@script` step an analyst writes. It uses pandas and numpy on the platform's image.
+- `demand_forecast.py`: the same logic as plain Python functions, the tested source of truth.
+- `test_demand_forecast.py`: a local test of that logic. Runs in milliseconds, no cluster.
+- `run_forecast.ipynb`: the notebook you press play in.
+- `workflow.py`: the same job as a plain script, for the terminal.
+
+## Log into Pipekit via the CLI
+
+With the [CLI installed](https://docs.pipekit.io/cli), log in once. This writes a token to `~/.pipekit/token` that the SDK reuses, so you do not paste a token anywhere.
+
+```bash
+pipekit login
+```
+
+## Set up the environment
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install hera pipekit-sdk ipykernel
+```
+
+pandas and numpy run on the cluster, not locally, so you do not need them here.
+
+## Run it from the notebook
+
+Open `run_forecast.ipynb`, select the `.venv` kernel (top right in VSCode), and run the cells top to bottom. Set your cluster name in the `Point at your cluster` cell if it is not `free-trial-cluster`. The run cell prints a link to watch the job live in the Pipekit UI, and a later cell pulls the forecast logs inline.
+
+## Run it from the terminal
+
+```bash
+.venv/bin/python workflow.py
+```
+
+It submits the job, prints a watch link, waits for the run to finish, and prints the logs.
+
+### Change the cluster name
+
+The default cluster name is `free-trial-cluster`. Set `PIPEKIT_CLUSTER` to use a different one:
+
+```bash
+export PIPEKIT_CLUSTER=my-cluster
+```
+
+## Test the logic locally
+
+```bash
+.venv/bin/python test_demand_forecast.py
+```
+
+The aggregation and forecast functions are plain Python, so you can test them in milliseconds before the job ever touches the cluster.

--- a/examples/hera-notebook-forecast/README.md
+++ b/examples/hera-notebook-forecast/README.md
@@ -25,21 +25,38 @@ pipekit login
 
 ## Set up the environment
 
+This repo ships a Nix dev shell (`shell.nix` at the repo root) that provides Python and the C++ runtime the Jupyter kernel needs on NixOS. From the repo root, inside the dev shell:
+
 ```bash
-python3 -m venv .venv
-.venv/bin/pip install hera pipekit-sdk ipykernel
+direnv allow                 # or run: nix-shell
+python -m venv .venv
+.venv/bin/pip install hera pipekit-sdk ipykernel jupyter
 ```
 
-pandas and numpy run on the cluster, not locally, so you do not need them here.
+`ipykernel` and `jupyter` let your editor run the notebook. pandas and numpy run on the cluster, not locally, so you do not need them here.
+
+## Register the kernel
+
+On NixOS the kernel needs `libstdc++` on `LD_LIBRARY_PATH`, or `pyzmq` fails to load and the editor reports that `jupyter and notebook` are missing. Bake that path into the kernel so it works however you launch your editor. Run this inside the dev shell, where `LD_LIBRARY_PATH` is set:
+
+```bash
+.venv/bin/python -m ipykernel install --user --name hera-forecast \
+  --display-name "Python (hera-forecast)" \
+  --env LD_LIBRARY_PATH "$LD_LIBRARY_PATH"
+```
+
+Re-run it after a nixpkgs upgrade or `nix-collect-garbage`, since the baked path points into the Nix store.
 
 ## Run it from the notebook
 
-Open `run_forecast.ipynb`, select the `.venv` kernel (top right in VSCode), and run the cells top to bottom. Set your cluster name in the `Point at your cluster` cell if it is not `free-trial-cluster`. The run cell prints a link to watch the job live in the Pipekit UI, and a later cell pulls the forecast logs inline.
+Open `examples/hera-notebook-forecast/run_forecast.ipynb` and select the `Python (hera-forecast)` kernel in the picker (top right), not a bare `Python 3.x` interpreter. Run the cells top to bottom. Set your cluster name in the `Point at your cluster` cell if it is not `free-trial-cluster`. The run cell prints a link to watch the job live in the Pipekit UI, and a later cell pulls the forecast logs inline.
 
 ## Run it from the terminal
 
+From the repo root, with the dev shell loaded:
+
 ```bash
-.venv/bin/python workflow.py
+.venv/bin/python examples/hera-notebook-forecast/workflow.py
 ```
 
 It submits the job, prints a watch link, waits for the run to finish, and prints the logs.
@@ -55,7 +72,7 @@ export PIPEKIT_CLUSTER=my-cluster
 ## Test the logic locally
 
 ```bash
-.venv/bin/python test_demand_forecast.py
+.venv/bin/python examples/hera-notebook-forecast/test_demand_forecast.py
 ```
 
 The aggregation and forecast functions are plain Python, so you can test them in milliseconds before the job ever touches the cluster.

--- a/examples/hera-notebook-forecast/dataplatform/__init__.py
+++ b/examples/hera-notebook-forecast/dataplatform/__init__.py
@@ -129,13 +129,21 @@ def logs(result, follow=False):
         print(f"[{line.pod_name}][{line.container_name}] {line.output}")
 
 
-def wait(result, poll_seconds=5):
-    """Poll until the run reaches a terminal state and return the final status string."""
+def wait(result, poll_seconds=5, timeout_seconds=3900):
+    """Poll until the run reaches a terminal state and return the final status string.
+
+    Raises TimeoutError if the run does not finish within timeout_seconds. The default
+    sits above the free trial cluster's 1 hour activeDeadlineSeconds, so a run that hits
+    its own deadline returns a terminal status before this fires.
+    """
     pipekit = _service()
     run_uuid = getattr(result, "uuid", result)
     terminal = {"completed", "failed", "stopped", "terminated"}
+    start = time.monotonic()
     status = pipekit.get_run(run_uuid).status
     while status not in terminal:
+        if time.monotonic() - start > timeout_seconds:
+            raise TimeoutError(f"run {run_uuid} did not finish within {timeout_seconds}s")
         time.sleep(poll_seconds)
         status = pipekit.get_run(run_uuid).status
     return status

--- a/examples/hera-notebook-forecast/dataplatform/__init__.py
+++ b/examples/hera-notebook-forecast/dataplatform/__init__.py
@@ -35,9 +35,12 @@ CLUSTER = os.environ.get("PIPEKIT_CLUSTER", "free-trial-cluster")
 _UI_URL = os.environ.get("PIPEKIT_URL", "https://pipekit.io")
 
 # Defaults the platform team controls. Analysts do not set these.
-# A public image with pandas and numpy preinstalled, so the job code reads like real
-# analyst work. Swap the tag (or set DATA_IMAGE) to pin a different version.
-DATA_IMAGE = os.environ.get("DATA_IMAGE", "amancevice/pandas:2.2.2-slim")
+# A pandas + numpy image so the job code reads like real analyst work. We use a Docker
+# Hub Verified Publisher namespace (demisto): the free trial cluster shares one egress
+# IP, and Docker Hub does not count pulls from Verified Publisher namespaces against the
+# anonymous rate limit, so this avoids the toomanyrequests pull failures that hit
+# community images. Swap the tag (or set DATA_IMAGE) to pin a different version.
+DATA_IMAGE = os.environ.get("DATA_IMAGE", "demisto/pandas:1.0.0.10120494")
 # The free trial cluster applies a 200Mi memory limit when a workflow omits one. We
 # set an explicit 512Mi request and limit to override that for the pandas step.
 DATA_RESOURCES = Resources(
@@ -99,11 +102,31 @@ def to_yaml(name, step):
 def logs(result, follow=False):
     """Print logs for a run. Pass the PipeRun from run()/submit(), or a run-uuid string.
 
-    follow=False prints a snapshot of what exists now. follow=True streams until the
-    run ends, which blocks the cell.
+    follow=True streams until the run ends (blocks the cell). Otherwise prints a
+    snapshot of the run's logs.
     """
     run_uuid = getattr(result, "uuid", result)
-    _service().print_logs(run_uuid, follow=follow)
+    pipekit = _service()
+    if follow:
+        pipekit.print_logs(run_uuid, follow=True)
+        return
+
+    # The SDK snapshot appends empty `pod-name=`/`container-name=` query params. The API
+    # parses each as a one-element [""] slice and adds a Loki matcher (podName="") that
+    # matches no stream, so the snapshot returns nothing for a finished run. Query the
+    # endpoint with no scope params, like the Pipekit UI and MCP, so it returns the logs.
+    import requests
+    from pipekit_sdk.models.model import Logs
+
+    response = requests.get(
+        f"{pipekit.users_url}/api/users/v1/runs/{run_uuid}/container_logs",
+        headers={"Authorization": f"Bearer {pipekit.access_token}"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    for entry in response.json() or []:
+        line = Logs.model_validate(entry)
+        print(f"[{line.pod_name}][{line.container_name}] {line.output}")
 
 
 def wait(result, poll_seconds=5):

--- a/examples/hera-notebook-forecast/dataplatform/__init__.py
+++ b/examples/hera-notebook-forecast/dataplatform/__init__.py
@@ -1,0 +1,118 @@
+"""The data platform team's internal Hera library.
+
+The platform team owns this module so data analysts never touch Kubernetes.
+The image, resource requests, namespace, service account, cluster name, and the
+Pipekit connection all live here behind sane defaults. An analyst writes a single
+Hera ``@script`` function and submits it:
+
+    from hera.workflows import script
+    from dataplatform import DATA_IMAGE, DATA_RESOURCES, run
+
+    @script(image=DATA_IMAGE, resources=DATA_RESOURCES)
+    def my_job():
+        print("hello from the cluster")
+
+    run("my-job", my_job)
+
+``run``/``submit`` send the workflow to Pipekit and print a link to watch it live.
+``logs(result)`` prints a log snapshot. ``to_yaml`` returns the same workflow as a
+manifest you can commit to git (the GitOps path).
+
+These defaults target the Pipekit free trial cluster: namespace ``argo``, service
+account ``argo-workflow`` (set explicitly, since the controller default is ``argo``
+whose task-result permissions live in another namespace), and the small resource
+footprint the trial cluster allows.
+"""
+
+import os
+import time
+
+from hera.workflows import Resources, Steps, Workflow
+
+# Connection. The SDK defaults its URL to https://api.pipekit.io, which is correct
+# for the free trial cluster, so PIPEKIT_URL only needs setting for a different env.
+CLUSTER = os.environ.get("PIPEKIT_CLUSTER", "free-trial-cluster")
+_UI_URL = os.environ.get("PIPEKIT_URL", "https://pipekit.io")
+
+# Defaults the platform team controls. Analysts do not set these.
+# A public image with pandas and numpy preinstalled, so the job code reads like real
+# analyst work. Swap the tag (or set DATA_IMAGE) to pin a different version.
+DATA_IMAGE = os.environ.get("DATA_IMAGE", "amancevice/pandas:2.2.2-slim")
+# The free trial cluster applies a 200Mi memory limit when a workflow omits one. We
+# set an explicit 512Mi request and limit to override that for the pandas step.
+DATA_RESOURCES = Resources(
+    cpu_request="250m",
+    cpu_limit="500m",
+    memory_request="512Mi",
+    memory_limit="512Mi",
+)
+
+_NAMESPACE = "argo"
+_SERVICE_ACCOUNT = "argo-workflow"
+
+
+def _service():
+    # token="" makes the SDK fall back to the credentials `pipekit login` wrote to
+    # ~/.pipekit/token. PIPEKIT_TOKEN or PIPEKIT_HERA_TOKEN override it for headless
+    # or CI use. The SDK reads PIPEKIT_URL on its own.
+    from pipekit_sdk.service import PipekitService
+
+    token = os.environ.get("PIPEKIT_TOKEN") or os.environ.get("PIPEKIT_HERA_TOKEN") or ""
+    return PipekitService(token=token)
+
+
+def _build(name, step):
+    """Wrap a single Hera @script function as a one-step workflow with platform defaults."""
+    with Workflow(
+        generate_name=f"{name}-",
+        entrypoint="main",
+        namespace=_NAMESPACE,
+        service_account_name=_SERVICE_ACCOUNT,
+    ) as workflow:
+        with Steps(name="main"):
+            # Calling the @script function inside the Steps context registers the step
+            # and its template.
+            step()
+    return workflow
+
+
+def submit(workflow):
+    """Submit a built Hera Workflow to Pipekit. Returns the PipeRun and prints a watch link."""
+    pipekit = _service()
+    pipe_run = pipekit.submit(workflow, CLUSTER)
+    run_info = pipekit.get_run(pipe_run.uuid)
+    print(f"submitted run {run_info.uuid}")
+    print(f"watch live: {_UI_URL}/pipes/{run_info.pipe_uuid}/runs/{run_info.uuid}")
+    return pipe_run
+
+
+def run(name, step):
+    """Build a one-step workflow from a @script function and submit it to Pipekit."""
+    return submit(_build(name, step))
+
+
+def to_yaml(name, step):
+    """Return the one-step workflow as a committable manifest, without submitting."""
+    return _build(name, step).to_yaml()
+
+
+def logs(result, follow=False):
+    """Print logs for a run. Pass the PipeRun from run()/submit(), or a run-uuid string.
+
+    follow=False prints a snapshot of what exists now. follow=True streams until the
+    run ends, which blocks the cell.
+    """
+    run_uuid = getattr(result, "uuid", result)
+    _service().print_logs(run_uuid, follow=follow)
+
+
+def wait(result, poll_seconds=5):
+    """Poll until the run reaches a terminal state and return the final status string."""
+    pipekit = _service()
+    run_uuid = getattr(result, "uuid", result)
+    terminal = {"completed", "failed", "stopped", "terminated"}
+    status = pipekit.get_run(run_uuid).status
+    while status not in terminal:
+        time.sleep(poll_seconds)
+        status = pipekit.get_run(run_uuid).status
+    return status

--- a/examples/hera-notebook-forecast/demand_forecast.py
+++ b/examples/hera-notebook-forecast/demand_forecast.py
@@ -1,0 +1,79 @@
+"""Pure-Python logic for the energy demand forecast job. No Hera, no cluster.
+
+It generates synthetic half-hourly demand readings (MW) for a few regions, rolls them
+up to daily energy totals (MWh), and fits a simple linear trend to forecast the next
+day's demand per region.
+
+These functions are the tested source of truth (see ``test_demand_forecast.py``); they
+run in milliseconds with the standard library alone. ``forecast_step.py`` mirrors this
+computation with pandas and numpy to run on the cluster.
+"""
+
+import math
+import random
+
+REGIONS = ["North", "Midlands", "South"]
+DAYS = 28
+PERIODS_PER_DAY = 48  # half-hourly settlement periods
+_BASE_MW = {"North": 1800.0, "Midlands": 2400.0, "South": 3200.0}
+_DAILY_TREND_MW = {"North": 6.0, "Midlands": 9.0, "South": 4.0}
+
+
+def make_readings(days=DAYS, periods_per_day=PERIODS_PER_DAY, seed=42):
+    """Return synthetic half-hourly demand readings as a list of dicts. Deterministic.
+
+    Each reading is {"region", "day", "period", "mw"}. Demand follows a regional base
+    load, a slow upward daily trend, an intraday peak around the evening, and noise.
+    """
+    rng = random.Random(seed)
+    readings = []
+    for region in REGIONS:
+        for day in range(days):
+            for period in range(periods_per_day):
+                hour = period / 2.0
+                intraday = 350.0 * math.sin((hour - 6.0) / 24.0 * 2.0 * math.pi)
+                mw = (
+                    _BASE_MW[region]
+                    + _DAILY_TREND_MW[region] * day
+                    + intraday
+                    + rng.uniform(-60.0, 60.0)
+                )
+                readings.append(
+                    {"region": region, "day": day, "period": period, "mw": round(mw, 1)}
+                )
+    return readings
+
+
+def daily_totals(readings):
+    """Aggregate half-hourly MW readings into daily energy totals (MWh) per region.
+
+    Each reading covers a half-hour, so its energy is mw * 0.5. Returns a list of
+    {"region", "day", "mwh"} sorted by region then day.
+    """
+    totals = {}
+    for r in readings:
+        key = (r["region"], r["day"])
+        totals[key] = totals.get(key, 0.0) + r["mw"] * 0.5
+    rows = [
+        {"region": region, "day": day, "mwh": round(mwh, 1)}
+        for (region, day), mwh in totals.items()
+    ]
+    return sorted(rows, key=lambda row: (row["region"], row["day"]))
+
+
+def forecast_next_day(daily, region):
+    """Forecast the next day's MWh for a region from a linear least-squares trend."""
+    series = sorted(
+        (row for row in daily if row["region"] == region), key=lambda row: row["day"]
+    )
+    xs = [row["day"] for row in series]
+    ys = [row["mwh"] for row in series]
+    n = len(xs)
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    variance = sum((x - mean_x) ** 2 for x in xs)
+    covariance = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    slope = covariance / variance if variance else 0.0
+    intercept = mean_y - slope * mean_x
+    next_day = xs[-1] + 1
+    return round(slope * next_day + intercept, 1)

--- a/examples/hera-notebook-forecast/demand_forecast.py
+++ b/examples/hera-notebook-forecast/demand_forecast.py
@@ -39,7 +39,7 @@ def make_readings(days=DAYS, periods_per_day=PERIODS_PER_DAY, seed=42):
                     + rng.uniform(-60.0, 60.0)
                 )
                 readings.append(
-                    {"region": region, "day": day, "period": period, "mw": round(mw, 1)}
+                    {"region": region, "day": day, "period": period, "mw": mw}
                 )
     return readings
 
@@ -66,6 +66,8 @@ def forecast_next_day(daily, region):
     series = sorted(
         (row for row in daily if row["region"] == region), key=lambda row: row["day"]
     )
+    if not series:
+        raise ValueError(f"no daily data for region {region}")
     xs = [row["day"] for row in series]
     ys = [row["mwh"] for row in series]
     n = len(xs)

--- a/examples/hera-notebook-forecast/forecast_step.py
+++ b/examples/hera-notebook-forecast/forecast_step.py
@@ -1,0 +1,66 @@
+"""The cluster step an analyst submits: a single Hera @script function.
+
+It imports the platform's image and resource defaults from ``dataplatform`` and uses
+Hera's ``@script`` decorator directly, so the analyst writes only their job. The body
+is self-contained (Hera ships it to the cluster) and mirrors the pure logic in
+``demand_forecast.py``, computed with pandas and numpy on the data image.
+"""
+
+from hera.workflows import script
+
+from dataplatform import DATA_IMAGE, DATA_RESOURCES
+
+
+@script(
+    image=DATA_IMAGE,
+    resources=DATA_RESOURCES,
+    command=["python"],
+    add_cwd_to_sys_path=False,
+)
+def forecast_demand():
+    import math
+    import random
+
+    import numpy as np
+    import pandas as pd
+
+    regions = ["North", "Midlands", "South"]
+    days, periods_per_day = 28, 48
+    base_mw = {"North": 1800.0, "Midlands": 2400.0, "South": 3200.0}
+    daily_trend_mw = {"North": 6.0, "Midlands": 9.0, "South": 4.0}
+
+    rng = random.Random(42)
+    rows = []
+    for region in regions:
+        for day in range(days):
+            for period in range(periods_per_day):
+                hour = period / 2.0
+                intraday = 350.0 * math.sin((hour - 6.0) / 24.0 * 2.0 * math.pi)
+                mw = (
+                    base_mw[region]
+                    + daily_trend_mw[region] * day
+                    + intraday
+                    + rng.uniform(-60.0, 60.0)
+                )
+                rows.append({"region": region, "day": day, "mw": mw})
+
+    df = pd.DataFrame(rows)
+    # Half-hourly MW to daily energy: each reading covers 0.5h.
+    df["mwh"] = df["mw"] * 0.5
+    daily = df.groupby(["region", "day"], as_index=False)["mwh"].sum().round(1)
+
+    print("=== Daily demand (MWh) by region, last 5 days ===")
+    recent = daily[daily["day"] >= days - 5]
+    print(recent.pivot(index="day", columns="region", values="mwh").to_string())
+
+    forecasts = {}
+    for region in regions:
+        series = daily[daily["region"] == region].sort_values("day")
+        slope, intercept = np.polyfit(series["day"], series["mwh"], 1)
+        forecasts[region] = round(float(slope * days + intercept), 1)
+
+    print("=== Next-day demand forecast (MWh) by region ===")
+    forecast_df = pd.DataFrame(
+        {"region": list(forecasts), "forecast_mwh": list(forecasts.values())}
+    )
+    print(forecast_df.to_string(index=False))

--- a/examples/hera-notebook-forecast/forecast_step.py
+++ b/examples/hera-notebook-forecast/forecast_step.py
@@ -6,9 +6,8 @@ is self-contained (Hera ships it to the cluster) and mirrors the pure logic in
 ``demand_forecast.py``, computed with pandas and numpy on the data image.
 """
 
-from hera.workflows import script
-
 from dataplatform import DATA_IMAGE, DATA_RESOURCES
+from hera.workflows import script
 
 
 @script(

--- a/examples/hera-notebook-forecast/run_forecast.ipynb
+++ b/examples/hera-notebook-forecast/run_forecast.ipynb
@@ -14,25 +14,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Prerequisites\n",
-    "\n",
-    "Install the Pipekit CLI, then log in once. This writes a token to `~/.pipekit/token` that the SDK reuses, so you do not paste a token into the notebook.\n",
-    "\n",
-    "```bash\n",
-    "brew install pipekit/tap/cli   # or see https://docs.pipekit.io/cli\n",
-    "pipekit login\n",
-    "```\n",
-    "\n",
-    "Create a virtual environment with the dependencies and a notebook kernel, then select it with the kernel picker (top right in VSCode):\n",
-    "\n",
-    "```bash\n",
-    "python3 -m venv .venv\n",
-    ".venv/bin/pip install hera pipekit-sdk ipykernel\n",
-    "```\n",
-    "\n",
-    "pandas and numpy run on the cluster, not locally, so you do not need them here."
-   ]
+   "source": "## Prerequisites\n\nInstall the Pipekit CLI, then log in once. This writes a token to `~/.pipekit/token` that the SDK reuses, so you do not paste a token into the notebook.\n\n```bash\nbrew install pipekit/tap/cli   # or see https://docs.pipekit.io/cli\npipekit login\n```\n\nThis repo ships a Nix dev shell (`shell.nix` at the repo root) that provides Python and the C++ runtime the Jupyter kernel needs on NixOS. From the repo root, inside the dev shell:\n\n```bash\ndirenv allow                 # or run: nix-shell\npython -m venv .venv\n.venv/bin/pip install hera pipekit-sdk ipykernel jupyter\n```\n\nOn NixOS the kernel needs `libstdc++` on `LD_LIBRARY_PATH`, or `pyzmq` fails to load and the editor reports that `jupyter and notebook` are missing. Bake that path into the kernel so it works however you launch your editor:\n\n```bash\n.venv/bin/python -m ipykernel install --user --name hera-forecast \\\n  --display-name \"Python (hera-forecast)\" \\\n  --env LD_LIBRARY_PATH \"$LD_LIBRARY_PATH\"\n```\n\nThen select the `Python (hera-forecast)` kernel for this notebook (kernel picker, top right), not a bare `Python 3.x` interpreter. Re-run the install command after a nixpkgs upgrade, since the baked path points into the Nix store.\n\npandas and numpy run on the cluster, not locally, so you do not need them here."
   },
   {
    "cell_type": "markdown",
@@ -90,22 +72,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Watch it run\n",
-    "\n",
-    "Open the link printed above to see the graph and live logs in the Pipekit UI. To pull a log snapshot inline instead, run the next cell. The forecast tables print in the step's logs once it completes."
-   ]
+   "source": "## Watch it run\n\nOpen the link printed above to see the graph and live logs in the Pipekit UI. To pull the logs inline, run the next cell: it waits for the run to finish, then prints the step's output (the forecast tables). The first run can take a couple of minutes while the image pulls."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from dataplatform import logs\n",
-    "\n",
-    "logs(result)  # add follow=True to stream until the run ends (blocks the cell)"
-   ]
+   "source": "from dataplatform import logs, wait\n\nwait(result)   # block until the run finishes, so its logs exist\nlogs(result)   # the forecast tables the step printed"
   },
   {
    "cell_type": "markdown",

--- a/examples/hera-notebook-forecast/run_forecast.ipynb
+++ b/examples/hera-notebook-forecast/run_forecast.ipynb
@@ -1,0 +1,143 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run an energy demand forecast from a notebook\n",
+    "\n",
+    "Press play to run a real data job on Pipekit: aggregate synthetic half-hourly demand into daily totals and forecast the next day, per region. No Kubernetes, no YAML, no `kubectl`.\n",
+    "\n",
+    "The platform team owns `dataplatform/` (image, resources, service account, namespace, connection). You write a single job and submit it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "Install the Pipekit CLI, then log in once. This writes a token to `~/.pipekit/token` that the SDK reuses, so you do not paste a token into the notebook.\n",
+    "\n",
+    "```bash\n",
+    "brew install pipekit/tap/cli   # or see https://docs.pipekit.io/cli\n",
+    "pipekit login\n",
+    "```\n",
+    "\n",
+    "Create a virtual environment with the dependencies and a notebook kernel, then select it with the kernel picker (top right in VSCode):\n",
+    "\n",
+    "```bash\n",
+    "python3 -m venv .venv\n",
+    ".venv/bin/pip install hera pipekit-sdk ipykernel\n",
+    "```\n",
+    "\n",
+    "pandas and numpy run on the cluster, not locally, so you do not need them here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\nimport sys\n\n# VSCode starts the kernel at the workspace root, not this folder. Point the\n# working dir at this example so `dataplatform` and `forecast_step` import.\nnb = globals().get('__vsc_ipynb_file__')\nhere = os.path.dirname(nb) if nb else os.getcwd()\nif not os.path.isdir(os.path.join(here, 'dataplatform')):\n    here = os.path.join(os.getcwd(), 'examples', 'hera-notebook-forecast')\nos.chdir(here)\nsys.path.insert(0, here)\nprint('working dir:', os.getcwd())"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Point at your cluster\n",
+    "\n",
+    "Set the name of your free trial cluster. If you used a different name when you provisioned it, change it here. The SDK targets `https://api.pipekit.io` by default, which is correct for the free trial; set `PIPEKIT_URL` only for a different environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['PIPEKIT_CLUSTER'] = 'free-trial-cluster'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What you write\n",
+    "\n",
+    "A single function. `forecast_demand` (in `forecast_step.py`) is a Hera `@script` step that aggregates demand and forecasts the next day with pandas. The platform image, resources, service account, and namespace come from `dataplatform`; you never set them. `run` submits to Pipekit and prints a link to watch it live."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataplatform import run\n",
+    "from forecast_step import forecast_demand\n",
+    "\n",
+    "result = run('daily-demand-forecast', forecast_demand)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Watch it run\n",
+    "\n",
+    "Open the link printed above to see the graph and live logs in the Pipekit UI. To pull a log snapshot inline instead, run the next cell. The forecast tables print in the step's logs once it completes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataplatform import logs\n",
+    "\n",
+    "logs(result)  # add follow=True to stream until the run ends (blocks the cell)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The same job as YAML (the GitOps path)\n",
+    "\n",
+    "`to_yaml` renders the manifest you would commit to a feature branch. Same Python, now a versioned artifact. Pipekit pins per-branch versions, so committing it does not overwrite anyone else's work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataplatform import to_yaml\n",
+    "\n",
+    "print(to_yaml('daily-demand-forecast', forecast_demand))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/hera-notebook-forecast/test_demand_forecast.py
+++ b/examples/hera-notebook-forecast/test_demand_forecast.py
@@ -1,0 +1,58 @@
+"""Local tests for the demand forecast logic. Standard library only, no cluster.
+
+Run with ``pytest``, or directly with ``python test_demand_forecast.py``.
+"""
+
+from demand_forecast import (
+    DAYS,
+    PERIODS_PER_DAY,
+    REGIONS,
+    daily_totals,
+    forecast_next_day,
+    make_readings,
+)
+
+
+def test_daily_totals_small_case():
+    readings = [
+        {"region": "North", "day": 0, "period": 0, "mw": 100.0},
+        {"region": "North", "day": 0, "period": 1, "mw": 200.0},
+        {"region": "North", "day": 1, "period": 0, "mw": 50.0},
+        {"region": "South", "day": 0, "period": 0, "mw": 80.0},
+    ]
+    assert daily_totals(readings) == [
+        {"region": "North", "day": 0, "mwh": 150.0},
+        {"region": "North", "day": 1, "mwh": 25.0},
+        {"region": "South", "day": 0, "mwh": 40.0},
+    ]
+
+
+def test_forecast_extends_a_linear_trend():
+    daily = [{"region": "X", "day": day, "mwh": 10.0 * day + 5.0} for day in range(5)]
+    assert forecast_next_day(daily, "X") == 55.0
+
+
+def test_make_readings_is_deterministic():
+    assert make_readings(days=3, seed=7) == make_readings(days=3, seed=7)
+
+
+def test_readings_cover_every_region_day_period():
+    readings = make_readings()
+    assert len(readings) == len(REGIONS) * DAYS * PERIODS_PER_DAY
+    assert len(daily_totals(readings)) == len(REGIONS) * DAYS
+
+
+def test_forecast_follows_the_upward_trend():
+    daily = daily_totals(make_readings())
+    for region in REGIONS:
+        series = [row["mwh"] for row in daily if row["region"] == region]
+        assert forecast_next_day(daily, region) > series[0]
+
+
+if __name__ == "__main__":
+    test_daily_totals_small_case()
+    test_forecast_extends_a_linear_trend()
+    test_make_readings_is_deterministic()
+    test_readings_cover_every_region_day_period()
+    test_forecast_follows_the_upward_trend()
+    print("all tests passed")

--- a/examples/hera-notebook-forecast/test_demand_forecast.py
+++ b/examples/hera-notebook-forecast/test_demand_forecast.py
@@ -49,10 +49,21 @@ def test_forecast_follows_the_upward_trend():
         assert forecast_next_day(daily, region) > series[0]
 
 
+def test_forecast_raises_on_unknown_region():
+    daily = daily_totals(make_readings(days=3))
+    try:
+        forecast_next_day(daily, "Atlantis")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for an unknown region")
+
+
 if __name__ == "__main__":
     test_daily_totals_small_case()
     test_forecast_extends_a_linear_trend()
     test_make_readings_is_deterministic()
     test_readings_cover_every_region_day_period()
     test_forecast_follows_the_upward_trend()
+    test_forecast_raises_on_unknown_region()
     print("all tests passed")

--- a/examples/hera-notebook-forecast/workflow.py
+++ b/examples/hera-notebook-forecast/workflow.py
@@ -1,0 +1,18 @@
+"""Run the demand forecast job from the terminal.
+
+The same job the notebook runs, as a plain script. Submits to Pipekit, prints a link
+to watch it live, waits for completion, and exits non-zero if the run fails.
+"""
+
+import sys
+
+from dataplatform import logs, run, wait
+from forecast_step import forecast_demand
+
+result = run("daily-demand-forecast", forecast_demand)
+status = wait(result)
+print(f"run status: {status}")
+
+logs(result)
+
+sys.exit(0 if status == "completed" else 1)

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  packages = with pkgs; [
+    python311
+    ruff
+  ];
+
+  # pip-installed binary wheels (pyzmq, pulled in by ipykernel) dlopen
+  # libstdc++.so.6, which is not on NixOS's default loader path, so the Jupyter
+  # kernel fails to start. Put the C++ runtime on LD_LIBRARY_PATH. Launch your
+  # editor from this directory (direnv loads this shell) so the kernel inherits it.
+  shellHook = ''
+    export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib pkgs.zlib ]}:''${LD_LIBRARY_PATH:-}"
+  '';
+}


### PR DESCRIPTION
## What

A new example, `hera-notebook-forecast`: an analyst presses play in a Jupyter notebook and a real data job runs on Pipekit, with Kubernetes hidden.

The job is an energy demand forecast. It builds synthetic half-hourly demand for a few regions, totals it per day, and forecasts the next day. The data is synthetic, but the shape is real work, not a coinflip.

It splits the way a platform team would:

- `dataplatform/`: the platform library. It sets the image, resources, service account, namespace, cluster, and the Pipekit connection. Analysts never touch it.
- `forecast_step.py`: the single Hera `@script` step an analyst writes.
- `demand_forecast.py` and `test_demand_forecast.py`: the same logic as plain Python, with a test that runs in milliseconds and needs no cluster.
- `run_forecast.ipynb`: the notebook you press play in. `workflow.py` is the same job for the terminal.

## Why

A prospect's data team wants their analysts to run a script from a notebook without learning Kubernetes. The defaults target the Pipekit free trial cluster, so it runs there out of the box. The example is generic, so any new trial can reuse it.

## Notes for reviewers

- The unit test and `ruff` pass. The Hera submit path is modeled on the existing `hera-coinflip` example but has not yet run against a live cluster.
- The job uses a public pandas image at a 512Mi limit. Confirm it pulls and schedules on a free trial cluster; `demand_forecast.py` holds a standard-library fallback if not.
- Not wired into `ci/ci.yaml`, to keep a heavier pandas run out of CI for now.