### PR TITLE
feat: stream logs live in the hera notebook

### DIFF
--- a/examples/hera-notebook-forecast/README.md
+++ b/examples/hera-notebook-forecast/README.md
@@ -49,7 +49,7 @@ Re-run it after a nixpkgs upgrade or `nix-collect-garbage`, since the baked path
 
 ## Run it from the notebook
 
-Open `examples/hera-notebook-forecast/run_forecast.ipynb` and select the `Python (hera-forecast)` kernel in the picker (top right), not a bare `Python 3.x` interpreter. Run the cells top to bottom. Set your cluster name in the `Point at your cluster` cell if it is not `free-trial-cluster`. The run cell prints a link to watch the job live in the Pipekit UI, and a later cell pulls the forecast logs inline.
+Open `examples/hera-notebook-forecast/run_forecast.ipynb` and select the `Python (hera-forecast)` kernel in the picker (top right), not a bare `Python 3.x` interpreter. Run the cells top to bottom. Set your cluster name in the `Point at your cluster` cell if it is not `free-trial-cluster`. The run cell prints a link to watch the job live in the Pipekit UI, and a later cell streams the forecast logs inline as the run produces them.
 
 ## Run it from the terminal
 

--- a/examples/hera-notebook-forecast/dataplatform/__init__.py
+++ b/examples/hera-notebook-forecast/dataplatform/__init__.py
@@ -99,16 +99,21 @@ def to_yaml(name, step):
     return _build(name, step).to_yaml()
 
 
-def logs(result, follow=False):
+def logs(result, follow=False, timeout_seconds=3900):
     """Print logs for a run. Pass the PipeRun from run()/submit(), or a run-uuid string.
 
-    follow=True streams until the run ends (blocks the cell). Otherwise prints a
-    snapshot of the run's logs.
+    follow=True streams the run's logs live: it backfills the history so far, then prints
+    new lines as they arrive, and returns when the run finishes. This blocks the cell while
+    the run is active. Otherwise it prints a one-off snapshot of the logs.
+
+    timeout_seconds caps how long follow=True waits. If the run never sends an end-of-stream
+    signal, the stream stops after this and prints a note, so the cell cannot hang forever.
+    The default matches wait().
     """
     run_uuid = getattr(result, "uuid", result)
     pipekit = _service()
     if follow:
-        pipekit.print_logs(run_uuid, follow=True)
+        _stream_logs(pipekit, run_uuid, timeout_seconds)
         return
 
     # The SDK snapshot appends empty `pod-name=`/`container-name=` query params. The API
@@ -127,6 +132,68 @@ def logs(result, follow=False):
     for entry in response.json() or []:
         line = Logs.model_validate(entry)
         print(f"[{line.pod_name}][{line.container_name}] {line.output}")
+
+
+def _stream_logs(pipekit, run_uuid, timeout_seconds):
+    """Stream a run's logs over Server-Sent Events until the run ends.
+
+    The SDK's follow path builds the stream URL with empty `pod-name=`/`container-name=`
+    params, which the API turns into a Loki matcher that matches no stream, so it prints
+    nothing. We hit `container_logs_stream` with no scope params, the same workaround the
+    snapshot path uses, and parse the SSE ourselves.
+
+    The server sends three kinds of `data:` events: a `ping` keep-alive every few seconds,
+    a JSON log line, and a final `close` once the run has been finished for two ticks. It
+    closes the stream itself about ten seconds after the run completes. We still keep a
+    wall-clock guard in case that `close` never arrives.
+    """
+    import json
+
+    import requests
+    from pipekit_sdk.models.model import Logs
+
+    url = f"{pipekit.users_url}/api/users/v1/runs/{run_uuid}/container_logs_stream"
+    deadline = time.monotonic() + timeout_seconds
+
+    # The server pings every few seconds, so a long read gap means the connection died.
+    # The read timeout ends the stream then; the deadline check ends a stream that keeps
+    # pinging past timeout_seconds without ever sending `close`.
+    response = requests.get(
+        url,
+        headers={
+            "Authorization": f"Bearer {pipekit.access_token}",
+            "Cache-Control": "no-cache",
+        },
+        stream=True,
+        timeout=(10, 60),
+    )
+    response.raise_for_status()
+
+    data_prefix = "data: "
+    try:
+        for raw in response.iter_lines(decode_unicode=True):
+            if time.monotonic() > deadline:
+                print(f"stopped following after {timeout_seconds}s; the run may still be active")
+                return
+
+            line = raw.strip() if raw else ""
+            # id: lines carry the event cursor and blank lines separate events; neither
+            # prints. Only data: events carry a ping, a log line, or the close signal.
+            if not line.startswith(data_prefix):
+                continue
+
+            payload = line[len(data_prefix) :]
+            if payload == "ping":
+                continue
+            if payload == "close":
+                return
+
+            entry = Logs.model_validate(json.loads(payload))
+            print(f"[{entry.pod_name}][{entry.container_name}] {entry.output}")
+    except requests.exceptions.Timeout:
+        print("log stream went quiet; the run may still be active. Re-run this cell to reconnect.")
+    finally:
+        response.close()
 
 
 def wait(result, poll_seconds=5, timeout_seconds=3900):

--- a/examples/hera-notebook-forecast/dataplatform/__init__.py
+++ b/examples/hera-notebook-forecast/dataplatform/__init__.py
@@ -134,6 +134,21 @@ def logs(result, follow=False, timeout_seconds=3900):
         print(f"[{line.pod_name}][{line.container_name}] {line.output}")
 
 
+_TERMINAL_STATES = {"completed", "failed", "stopped", "terminated"}
+
+
+def _run_status(pipekit, run_uuid):
+    """Return the run's status, or "" if the status check itself fails.
+
+    Used only to decide whether to keep reconnecting, so a transient failure here should
+    not stop the stream. An unknown status reads as not-terminal and we keep waiting.
+    """
+    try:
+        return pipekit.get_run(run_uuid).status
+    except Exception:  # noqa: BLE001 - best-effort check; any failure means "keep waiting"
+        return ""
+
+
 def _stream_logs(pipekit, run_uuid, timeout_seconds):
     """Stream a run's logs over Server-Sent Events until the run ends.
 
@@ -143,9 +158,13 @@ def _stream_logs(pipekit, run_uuid, timeout_seconds):
     snapshot path uses, and parse the SSE ourselves.
 
     The server sends three kinds of `data:` events: a `ping` keep-alive every few seconds,
-    a JSON log line, and a final `close` once the run has been finished for two ticks. It
-    closes the stream itself about ten seconds after the run completes. We still keep a
-    wall-clock guard in case that `close` never arrives.
+    a JSON log line, and a final `close` once the run has been finished for two ticks. The
+    chunked connection can drop before `close` arrives. On a busy cluster the pod can be
+    slow to start, and the connection may drop several times before any logs appear. We
+    reconnect from the last event id we saw, so the resumed stream does not replay the
+    backfill, and we keep reconnecting while the run is still pending or running. We stop
+    once the run reaches a terminal state or the wall-clock deadline passes, so the cell
+    cannot hang.
     """
     import json
 
@@ -154,46 +173,82 @@ def _stream_logs(pipekit, run_uuid, timeout_seconds):
 
     url = f"{pipekit.users_url}/api/users/v1/runs/{run_uuid}/container_logs_stream"
     deadline = time.monotonic() + timeout_seconds
-
-    # The server pings every few seconds, so a long read gap means the connection died.
-    # The read timeout ends the stream then; the deadline check ends a stream that keeps
-    # pinging past timeout_seconds without ever sending `close`.
-    response = requests.get(
-        url,
-        headers={
-            "Authorization": f"Bearer {pipekit.access_token}",
-            "Cache-Control": "no-cache",
-        },
-        stream=True,
-        timeout=(10, 60),
-    )
-    response.raise_for_status()
-
     data_prefix = "data: "
-    try:
-        for raw in response.iter_lines(decode_unicode=True):
-            if time.monotonic() > deadline:
-                print(f"stopped following after {timeout_seconds}s; the run may still be active")
-                return
+    id_prefix = "id: "
+    last_event_id = ""
+    printed_any_log = False
+    waiting_notice_shown = False
+    backoff_seconds = 1
 
-            line = raw.strip() if raw else ""
-            # id: lines carry the event cursor and blank lines separate events; neither
-            # prints. Only data: events carry a ping, a log line, or the close signal.
-            if not line.startswith(data_prefix):
-                continue
+    # Connection-level drops, not bad responses. raise_for_status() still raises on a
+    # 4xx/5xx, so a real auth or routing error surfaces instead of looping.
+    transient = (
+        requests.exceptions.ChunkedEncodingError,
+        requests.exceptions.ConnectionError,
+        requests.exceptions.Timeout,
+    )
 
-            payload = line[len(data_prefix) :]
-            if payload == "ping":
-                continue
-            if payload == "close":
-                return
+    while time.monotonic() < deadline:
+        # last-event-id resumes the stream after the last line we printed, so a reconnect
+        # does not replay the whole history. The server pings every few seconds, so a 60s
+        # read gap means the connection is dead.
+        response = requests.get(
+            url,
+            headers={
+                "Authorization": f"Bearer {pipekit.access_token}",
+                "Cache-Control": "no-cache",
+                "last-event-id": last_event_id,
+            },
+            stream=True,
+            timeout=(10, 60),
+        )
+        response.raise_for_status()
 
-            entry = Logs.model_validate(json.loads(payload))
-            print(f"[{entry.pod_name}][{entry.container_name}] {entry.output}")
-    except requests.exceptions.Timeout:
-        print("log stream went quiet; the run may still be active. Re-run this cell to reconnect.")
-    finally:
-        response.close()
+        try:
+            for raw in response.iter_lines(decode_unicode=True):
+                if time.monotonic() > deadline:
+                    print(f"stopped following after {timeout_seconds}s; the run may still be active")
+                    return
+
+                line = raw.strip() if raw else ""
+                if not line:
+                    continue
+
+                if line.startswith(id_prefix):
+                    last_event_id = line[len(id_prefix) :]
+                    continue
+                if not line.startswith(data_prefix):
+                    continue
+
+                payload = line[len(data_prefix) :]
+                if payload == "ping":
+                    continue
+                if payload == "close":
+                    return
+
+                # A real log line means the stream is healthy, so reset the backoff.
+                backoff_seconds = 1
+                printed_any_log = True
+                entry = Logs.model_validate(json.loads(payload))
+                print(f"[{entry.pod_name}][{entry.container_name}] {entry.output}")
+        except transient:
+            pass  # the connection dropped; the status check below decides what to do
+        finally:
+            response.close()
+
+        # The stream ended without a `close`. Reconnect only while the run is still active.
+        # A terminal run that dropped its stream is genuinely finished, so stop there.
+        if _run_status(pipekit, run_uuid) in _TERMINAL_STATES:
+            return
+        # Before any logs appear, tell the user we are waiting on the pod. After logs have
+        # started, a drop reconnects silently and resumes from last_event_id.
+        if not printed_any_log and not waiting_notice_shown:
+            print("waiting for the run to produce logs (the pod may still be starting)...")
+            waiting_notice_shown = True
+        time.sleep(backoff_seconds)
+        backoff_seconds = min(backoff_seconds * 2, 10)
+
+    print(f"stopped following after {timeout_seconds}s; the run may still be active")
 
 
 def wait(result, poll_seconds=5, timeout_seconds=3900):

--- a/examples/hera-notebook-forecast/run_forecast.ipynb
+++ b/examples/hera-notebook-forecast/run_forecast.ipynb
@@ -72,14 +72,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Watch it run\n\nOpen the link printed above to see the graph and live logs in the Pipekit UI. To pull the logs inline, run the next cell: it waits for the run to finish, then prints the step's output (the forecast tables). The first run can take a couple of minutes while the image pulls."
+   "source": "## Watch it run\n\nOpen the link printed above to see the graph and live logs in the Pipekit UI. To stream the logs inline, run the next cell: it follows the run and prints each line as it arrives, then returns when the run finishes. The cell blocks while the run is active, which is how streaming works. The first run can take a couple of minutes while the image pulls.\n\nOn the free trial cluster each line currently arrives twice. That is a known duplicate-ingestion bug, not your job running twice."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "from dataplatform import logs, wait\n\nwait(result)   # block until the run finishes, so its logs exist\nlogs(result)   # the forecast tables the step printed"
+   "source": "from dataplatform import logs\n\nlogs(result, follow=True)   # stream the forecast tables live as the run produces them"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## What changed

Before: the notebook's logs cell called `wait(result)` and then printed a one-off snapshot after the run finished.

After: the cell streams logs live with `logs(result, follow=True)`. It prints each line as the run produces it.

## Why

During a demo, an engineer asked for the example to stream logs live as the workflow runs.

The SDK's `print_logs(follow=True)` builds the stream URL with empty `pod-name=`/`container-name=` params, so it hits #12541 and streams nothing. Our `logs(follow=True)` delegated to it, so it was broken the same way.

## How

- Rewrote the `follow=True` branch of `dataplatform.logs()`. It now calls `container_logs_stream` directly with no scope params, the same workaround the snapshot path already uses. It parses the SSE events (`id:`, `data:`, `ping`, `close`) and prints lines until `close`.
- The chunked connection can drop before `close` arrives. On a busy cluster the pod can be slow to start, so the connection may drop several times before any logs appear. The stream reconnects from the last event id and keeps retrying while the run is still pending or running. It resumes without replaying the backfill, and prints a one-time notice while it waits for the pod to start.
- The stream stops once the run reaches a terminal state or the wall-clock time limit passes (`timeout_seconds`, default 3900), so the cell cannot hang.
- Updated `run_forecast.ipynb` to stream during the run instead of wait-then-snapshot.
- Left `workflow.py` (the terminal path) unchanged. It uses the status that `wait()` returns for its exit code.

## Caveats to set with the customer

- The cell blocks while streaming until the run finishes. That is inherent to streaming.
- On the free trial cluster, each line arrives twice until #12543 is fixed.

## Testing

- `ruff` and `cspell` pass.
- Fed the exact SSE bytes the handler emits through the parse logic. It handled `id:`, `ping`, log lines, and `close` correctly.
- Tested against a customer free trial cluster

Closes #12545
