### PR TITLE
feat: add a CronWorkflow demo notebook to the hera forecast example

### DIFF
--- a/examples/hera-notebook-forecast/README.md
+++ b/examples/hera-notebook-forecast/README.md
@@ -65,7 +65,7 @@ cron('daily-demand-forecast', forecast_demand, schedule='0 6 * * *')
 
 The cell prints a link to the cron's run history in the UI. Each tick of the schedule starts a new run there. The same step runs with the same platform defaults as the one-off path. A `cron_to_yaml` cell renders the manifest for the GitOps path. It is the same kind of `CronWorkflow` as the native `examples/cronworkflow-example/workflow.yaml`, with the schedule in the `schedules` list that Argo Workflows 3.6 requires.
 
-Creating a cron is in the SDK. Managing it after creation (suspend, resume, delete, trigger) is a CLI or UI task. See the [cron CLI commands](https://docs.pipekit.io/cli/cron-workflows).
+`cron` is idempotent on the name. Run it again with a different schedule and it updates the existing cron in place, so re-running the cell does not fail. The notebook also manages the cron from the SDK: `get_cron` reads its current state, `suspend_cron` and `resume_cron` pause and restart the schedule, and `delete_cron` removes it. These helpers need pipekit-sdk 2.1.2 or newer. Triggering an on-demand run is still a CLI or UI action; see the [cron CLI commands](https://docs.pipekit.io/cli/cron-workflows).
 
 ## Run it from the terminal
 

--- a/examples/hera-notebook-forecast/README.md
+++ b/examples/hera-notebook-forecast/README.md
@@ -12,7 +12,8 @@ This example splits the work the way a platform team would:
 - `forecast_step.py`: the single Hera `@script` step an analyst writes. It uses pandas and numpy on the platform's image.
 - `demand_forecast.py`: the same logic as plain Python functions, the tested source of truth.
 - `test_demand_forecast.py`: a local test of that logic. Runs in milliseconds, no cluster.
-- `run_forecast.ipynb`: the notebook you press play in.
+- `run_forecast.ipynb`: the notebook you press play in to run the job once.
+- `cron_forecast.ipynb`: the notebook that schedules the same job as a recurring cron.
 - `workflow.py`: the same job as a plain script, for the terminal.
 
 ## Log into Pipekit via the CLI
@@ -50,6 +51,21 @@ Re-run it after a nixpkgs upgrade or `nix-collect-garbage`, since the baked path
 ## Run it from the notebook
 
 Open `examples/hera-notebook-forecast/run_forecast.ipynb` and select the `Python (hera-forecast)` kernel in the picker (top right), not a bare `Python 3.x` interpreter. Run the cells top to bottom. Set your cluster name in the `Point at your cluster` cell if it is not `free-trial-cluster`. The run cell prints a link to watch the job live in the Pipekit UI, and a later cell streams the forecast logs inline as the run produces them.
+
+## Schedule it on a cron
+
+Open `examples/hera-notebook-forecast/cron_forecast.ipynb` and run the cells top to bottom, the same way. Instead of running the job once, it schedules the job as a `CronWorkflow` with one call:
+
+```python
+from dataplatform import cron
+from forecast_step import forecast_demand
+
+cron('daily-demand-forecast', forecast_demand, schedule='0 6 * * *')
+```
+
+The cell prints a link to the cron's run history in the UI. Each tick of the schedule starts a new run there. The same step runs with the same platform defaults as the one-off path. A `cron_to_yaml` cell renders the manifest for the GitOps path, matching the native `examples/cronworkflow-example/workflow.yaml`.
+
+Creating a cron is in the SDK. Managing it after creation (suspend, resume, delete, trigger) is a CLI or UI task. See the [cron CLI commands](https://docs.pipekit.io/cli/cron-workflows).
 
 ## Run it from the terminal
 

--- a/examples/hera-notebook-forecast/README.md
+++ b/examples/hera-notebook-forecast/README.md
@@ -63,7 +63,7 @@ from forecast_step import forecast_demand
 cron('daily-demand-forecast', forecast_demand, schedule='0 6 * * *')
 ```
 
-The cell prints a link to the cron's run history in the UI. Each tick of the schedule starts a new run there. The same step runs with the same platform defaults as the one-off path. A `cron_to_yaml` cell renders the manifest for the GitOps path, matching the native `examples/cronworkflow-example/workflow.yaml`.
+The cell prints a link to the cron's run history in the UI. Each tick of the schedule starts a new run there. The same step runs with the same platform defaults as the one-off path. A `cron_to_yaml` cell renders the manifest for the GitOps path. It is the same kind of `CronWorkflow` as the native `examples/cronworkflow-example/workflow.yaml`, with the schedule in the `schedules` list that Argo Workflows 3.6 requires.
 
 Creating a cron is in the SDK. Managing it after creation (suspend, resume, delete, trigger) is a CLI or UI task. See the [cron CLI commands](https://docs.pipekit.io/cli/cron-workflows).
 

--- a/examples/hera-notebook-forecast/cron_forecast.ipynb
+++ b/examples/hera-notebook-forecast/cron_forecast.ipynb
@@ -1,0 +1,103 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Schedule an energy demand forecast from a notebook\n",
+    "\n",
+    "Press play to schedule the same data job on Pipekit as a recurring `CronWorkflow`: aggregate synthetic half-hourly demand into daily totals and forecast the next day, per region. No Kubernetes, no YAML, no `kubectl`.\n",
+    "\n",
+    "The platform team owns `dataplatform/` (image, resources, service account, namespace, connection). You write a single job and schedule it. The one-off version of this job is in `run_forecast.ipynb`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Prerequisites\n\nInstall the Pipekit CLI, then log in once. This writes a token to `~/.pipekit/token` that the SDK reuses, so you do not paste a token into the notebook.\n\n```bash\nbrew install pipekit/tap/cli   # or see https://docs.pipekit.io/cli\npipekit login\n```\n\nThis repo ships a Nix dev shell (`shell.nix` at the repo root) that provides Python and the C++ runtime the Jupyter kernel needs on NixOS. From the repo root, inside the dev shell:\n\n```bash\ndirenv allow                 # or run: nix-shell\npython -m venv .venv\n.venv/bin/pip install hera pipekit-sdk ipykernel jupyter\n```\n\nOn NixOS the kernel needs `libstdc++` on `LD_LIBRARY_PATH`, or `pyzmq` fails to load and the editor reports that `jupyter and notebook` are missing. Bake that path into the kernel so it works however you launch your editor:\n\n```bash\n.venv/bin/python -m ipykernel install --user --name hera-forecast \\\n  --display-name \"Python (hera-forecast)\" \\\n  --env LD_LIBRARY_PATH \"$LD_LIBRARY_PATH\"\n```\n\nThen select the `Python (hera-forecast)` kernel for this notebook (kernel picker, top right), not a bare `Python 3.x` interpreter. Re-run the install command after a nixpkgs upgrade, since the baked path points into the Nix store.\n\npandas and numpy run on the cluster, not locally, so you do not need them here."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\nimport sys\n\n# VSCode starts the kernel at the workspace root, not this folder. Point the\n# working dir at this example so `dataplatform` and `forecast_step` import.\nnb = globals().get('__vsc_ipynb_file__')\nhere = os.path.dirname(nb) if nb else os.getcwd()\nif not os.path.isdir(os.path.join(here, 'dataplatform')):\n    here = os.path.join(os.getcwd(), 'examples', 'hera-notebook-forecast')\nos.chdir(here)\nsys.path.insert(0, here)\nprint('working dir:', os.getcwd())"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Point at your cluster\n",
+    "\n",
+    "Set the name of your free trial cluster. If you used a different name when you provisioned it, change it here. The SDK targets `https://api.pipekit.io` by default, which is correct for the free trial; set `PIPEKIT_URL` only for a different environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['PIPEKIT_CLUSTER'] = 'free-trial-cluster'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What you schedule\n",
+    "\n",
+    "The same single function as the one-off run, now on a schedule. `forecast_demand` (in `forecast_step.py`) is a Hera `@script` step that aggregates demand and forecasts the next day with pandas. The platform image, resources, service account, and namespace come from `dataplatform`; you never set them.\n",
+    "\n",
+    "`cron` builds a `CronWorkflow` from that step and creates it on Pipekit. The schedule is a standard cron expression: `0 6 * * *` runs the job at 06:00 every day. The cron has a stable name, so running this cell again updates the same cron rather than making a second one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from dataplatform import cron\nfrom forecast_step import forecast_demand\n\nresult = cron('daily-demand-forecast', forecast_demand, schedule='0 6 * * *')"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Watch the run history\n\nOpen the link printed above. The cron has no runs yet; each tick of the schedule starts a new run, and they collect on that page over time. To see a run now without waiting for the schedule, trigger the cron once from the CLI:\n\n```bash\npipekit trigger cron --cluster-name=free-trial-cluster daily-demand-forecast\n```\n\nManaging a cron after you create it (suspend, resume, delete, trigger) is a CLI and UI task, not an SDK one. The SDK creates cron workflows; it does not manage their lifecycle. See the [cron CLI commands](https://docs.pipekit.io/cli/cron-workflows)."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The same cron as YAML (the GitOps path)\n",
+    "\n",
+    "`cron_to_yaml` renders the manifest you would commit to a feature branch, without creating the cron. Same Python, now a versioned artifact. The output matches the native `examples/cronworkflow-example/workflow.yaml`, so you can move between the SDK path and a checked-in manifest without rewriting the job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from dataplatform import cron_to_yaml\n\nprint(cron_to_yaml('daily-demand-forecast', forecast_demand, schedule='0 6 * * *'))"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/hera-notebook-forecast/cron_forecast.ipynb
+++ b/examples/hera-notebook-forecast/cron_forecast.ipynb
@@ -51,19 +51,100 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## What you schedule\n\nThe same single function as the one-off run, now on a schedule. `forecast_demand` (in `forecast_step.py`) is a Hera `@script` step that aggregates demand and forecasts the next day with pandas. The platform image, resources, service account, and namespace come from `dataplatform`; you never set them.\n\n`cron` builds a `CronWorkflow` from that step and creates it on Pipekit. The schedule is a standard cron expression: `0 6 * * *` runs the job at 06:00 every day. The SDK creates crons but does not update them, so if a cron with this name already exists, the cell stops with a message that says how to recover. To change a cron, delete it from the UI or CLI first, or create the new one under a different name."
+   "source": [
+    "## What you schedule\n",
+    "\n",
+    "The same single function as the one-off run, now on a schedule. `forecast_demand` (in `forecast_step.py`) is a Hera `@script` step that aggregates demand and forecasts the next day with pandas. The platform image, resources, service account, and namespace come from `dataplatform`; you never set them.\n",
+    "\n",
+    "`cron` builds a `CronWorkflow` from that step and creates it on Pipekit. The schedule is a standard cron expression: `0 6 * * *` runs the job at 06:00 every day. The call is idempotent on the name: run it again with a changed schedule and it updates the existing cron, so there is no delete-first step. The lifecycle helpers below need pipekit-sdk 2.1.2 or newer."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "from dataplatform import cron\nfrom forecast_step import forecast_demand\n\nresult = cron('daily-demand-forecast', forecast_demand, schedule='0 6 * * *')"
+   "source": [
+    "from dataplatform import cron\n",
+    "from forecast_step import forecast_demand\n",
+    "\n",
+    "cron('daily-demand-forecast', forecast_demand, schedule='0 6 * * *')"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Watch the run history\n\nOpen the link printed above. The cron has no runs yet; each tick of the schedule starts a new run, and they collect on that page over time. To see a run now without waiting for the schedule, trigger the cron once from the CLI:\n\n```bash\npipekit trigger cron --cluster-name=free-trial-cluster --namespace=argo daily-demand-forecast\n```\n\nThe `--namespace=argo` flag matches the namespace the platform defaults use. Without it, the CLI looks in the wrong namespace and reports that the cron does not exist. The same flag applies to the other lifecycle commands (suspend, resume, delete).\n\nManaging a cron after you create it (suspend, resume, delete, trigger) is a CLI and UI task, not an SDK one. The SDK creates cron workflows; it does not manage their lifecycle. See the [cron CLI commands](https://docs.pipekit.io/cli/cron-workflows)."
+   "source": [
+    "## Watch the run history\n",
+    "\n",
+    "Open the link printed above. The cron has no runs yet; each tick of the schedule starts a new run, and they collect on that page over time. To see a run now without waiting for the schedule, trigger the cron once from the CLI:\n",
+    "\n",
+    "```bash\n",
+    "pipekit trigger cron --cluster-name=free-trial-cluster --namespace=argo daily-demand-forecast\n",
+    "```\n",
+    "\n",
+    "The `--namespace=argo` flag matches the namespace the platform defaults use. Without it, the CLI looks in the wrong namespace and reports that the cron does not exist. Triggering an on-demand run is a CLI or UI action; the SDK does not have it. The cells below manage the rest of the cron's lifecycle (update, check, suspend, resume) from the SDK. See the [cron CLI commands](https://docs.pipekit.io/cli/cron-workflows) for the CLI equivalents."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Update the schedule\n",
+    "\n",
+    "`cron` is idempotent on the name. Run it again with a different schedule and it updates the existing cron in place, with no delete first. Here the forecast moves from once a day to every four hours."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cron('daily-demand-forecast', forecast_demand, schedule='0 */4 * * *')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check the cron\n",
+    "\n",
+    "`get_cron` fetches the live cron and prints its schedule and whether it is suspended. It returns the full cron spec, so you can read other fields off the returned object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataplatform import get_cron\n",
+    "\n",
+    "get_cron('daily-demand-forecast')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Suspend and resume\n",
+    "\n",
+    "`suspend_cron` pauses the schedule so no new runs start; runs already going keep running. `resume_cron` turns it back on. The `get_cron` call in between shows the state flip from active to suspended."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataplatform import resume_cron, suspend_cron\n",
+    "\n",
+    "suspend_cron('daily-demand-forecast')\n",
+    "get_cron('daily-demand-forecast')\n",
+    "resume_cron('daily-demand-forecast')"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/examples/hera-notebook-forecast/cron_forecast.ipynb
+++ b/examples/hera-notebook-forecast/cron_forecast.ipynb
@@ -63,7 +63,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Watch the run history\n\nOpen the link printed above. The cron has no runs yet; each tick of the schedule starts a new run, and they collect on that page over time. To see a run now without waiting for the schedule, trigger the cron once from the CLI:\n\n```bash\npipekit trigger cron --cluster-name=free-trial-cluster daily-demand-forecast\n```\n\nManaging a cron after you create it (suspend, resume, delete, trigger) is a CLI and UI task, not an SDK one. The SDK creates cron workflows; it does not manage their lifecycle. See the [cron CLI commands](https://docs.pipekit.io/cli/cron-workflows)."
+   "source": "## Watch the run history\n\nOpen the link printed above. The cron has no runs yet; each tick of the schedule starts a new run, and they collect on that page over time. To see a run now without waiting for the schedule, trigger the cron once from the CLI:\n\n```bash\npipekit trigger cron --cluster-name=free-trial-cluster --namespace=argo daily-demand-forecast\n```\n\nThe `--namespace=argo` flag matches the namespace the platform defaults use. Without it, the CLI looks in the wrong namespace and reports that the cron does not exist. The same flag applies to the other lifecycle commands (suspend, resume, delete).\n\nManaging a cron after you create it (suspend, resume, delete, trigger) is a CLI and UI task, not an SDK one. The SDK creates cron workflows; it does not manage their lifecycle. See the [cron CLI commands](https://docs.pipekit.io/cli/cron-workflows)."
   },
   {
    "cell_type": "markdown",

--- a/examples/hera-notebook-forecast/cron_forecast.ipynb
+++ b/examples/hera-notebook-forecast/cron_forecast.ipynb
@@ -51,13 +51,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## What you schedule\n",
-    "\n",
-    "The same single function as the one-off run, now on a schedule. `forecast_demand` (in `forecast_step.py`) is a Hera `@script` step that aggregates demand and forecasts the next day with pandas. The platform image, resources, service account, and namespace come from `dataplatform`; you never set them.\n",
-    "\n",
-    "`cron` builds a `CronWorkflow` from that step and creates it on Pipekit. The schedule is a standard cron expression: `0 6 * * *` runs the job at 06:00 every day. The cron has a stable name, so running this cell again updates the same cron rather than making a second one."
-   ]
+   "source": "## What you schedule\n\nThe same single function as the one-off run, now on a schedule. `forecast_demand` (in `forecast_step.py`) is a Hera `@script` step that aggregates demand and forecasts the next day with pandas. The platform image, resources, service account, and namespace come from `dataplatform`; you never set them.\n\n`cron` builds a `CronWorkflow` from that step and creates it on Pipekit. The schedule is a standard cron expression: `0 6 * * *` runs the job at 06:00 every day. The SDK creates crons but does not update them, so if a cron with this name already exists, the cell stops with a message that says how to recover. To change a cron, delete it from the UI or CLI first, or create the new one under a different name."
   },
   {
    "cell_type": "code",
@@ -74,11 +68,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## The same cron as YAML (the GitOps path)\n",
-    "\n",
-    "`cron_to_yaml` renders the manifest you would commit to a feature branch, without creating the cron. Same Python, now a versioned artifact. The output matches the native `examples/cronworkflow-example/workflow.yaml`, so you can move between the SDK path and a checked-in manifest without rewriting the job."
-   ]
+   "source": "## The same cron as YAML (the GitOps path)\n\n`cron_to_yaml` renders the manifest you would commit to a feature branch, without creating the cron. Same Python, now a versioned artifact. It is the same kind of `CronWorkflow` manifest as the native `examples/cronworkflow-example/workflow.yaml`, so you can move between the SDK path and a checked-in manifest without rewriting the job. One difference: this manifest puts the schedule in the `schedules` list, which Argo Workflows 3.6 requires, while the older native example uses the deprecated singular `schedule` field."
   },
   {
    "cell_type": "code",

--- a/examples/hera-notebook-forecast/dataplatform/__init__.py
+++ b/examples/hera-notebook-forecast/dataplatform/__init__.py
@@ -107,13 +107,17 @@ def _build_cron(name, step, schedule, concurrency_policy="Replace", starting_dea
     name, not generate_name, so creating it again targets the same cron object. Each tick of
     the schedule starts a new run under that cron. concurrency_policy and
     starting_deadline_seconds match the native examples/cronworkflow-example.
+
+    The schedule goes into the `schedules` list, not the older singular `schedule` field.
+    Argo Workflows 3.6 deprecated `schedule` and the cluster CRD now requires `schedules`,
+    so the singular field fails validation with "spec.schedules: Required value".
     """
     with CronWorkflow(
         name=name,
         entrypoint="main",
         namespace=_NAMESPACE,
         service_account_name=_SERVICE_ACCOUNT,
-        schedule=schedule,
+        schedules=[schedule],
         concurrency_policy=concurrency_policy,
         starting_deadline_seconds=starting_deadline_seconds,
         timezone=timezone,
@@ -124,10 +128,25 @@ def _build_cron(name, step, schedule, concurrency_policy="Replace", starting_dea
 
 
 def create_cron(cron_workflow):
-    """Create a built CronWorkflow on Pipekit. Returns the PipeRun and prints a run-history link."""
+    """Create a built CronWorkflow on Pipekit. Returns the PipeRun and prints a run-history link.
+
+    The SDK only creates crons, it cannot update them. Creating one whose name already exists
+    on the cluster fails. We turn that one API error into a clear message that says how to
+    recover, since an analyst re-running the cell is the common way to hit it.
+    """
     pipekit = _service()
-    pipe_run = pipekit.create(cron_workflow, CLUSTER)
-    print(f"created cron {cron_workflow.name} (schedule {cron_workflow.schedule})")
+    try:
+        pipe_run = pipekit.create(cron_workflow, CLUSTER)
+    except Exception as err:
+        if "already exists" in str(err):
+            raise RuntimeError(
+                f"a cron named {cron_workflow.name!r} already exists on {CLUSTER}. The SDK creates "
+                "crons but cannot update them. Delete the existing cron from the Pipekit UI or CLI, "
+                "or create this one under a different name, then run this cell again."
+            ) from err
+        raise
+    schedule = ", ".join(cron_workflow.schedules or [])
+    print(f"created cron {cron_workflow.name} (schedule {schedule})")
     print(f"run history: {_UI_URL}/pipes/{pipe_run.pipe_uuid}")
     return pipe_run
 

--- a/examples/hera-notebook-forecast/dataplatform/__init__.py
+++ b/examples/hera-notebook-forecast/dataplatform/__init__.py
@@ -16,7 +16,8 @@ Hera ``@script`` function and submits it:
 
 ``run``/``submit`` send the workflow to Pipekit and print a link to watch it live.
 ``logs(result)`` prints a log snapshot. ``to_yaml`` returns the same workflow as a
-manifest you can commit to git (the GitOps path).
+manifest you can commit to git (the GitOps path). ``cron`` schedules the same job to
+run on a recurring basis.
 
 These defaults target the Pipekit free trial cluster: namespace ``argo``, service
 account ``argo-workflow`` (set explicitly, since the controller default is ``argo``
@@ -27,7 +28,7 @@ footprint the trial cluster allows.
 import os
 import time
 
-from hera.workflows import Resources, Steps, Workflow
+from hera.workflows import CronWorkflow, Resources, Steps, Workflow
 
 # Connection. The SDK defaults its URL to https://api.pipekit.io, which is correct
 # for the free trial cluster, so PIPEKIT_URL only needs setting for a different env.
@@ -97,6 +98,55 @@ def run(name, step):
 def to_yaml(name, step):
     """Return the one-step workflow as a committable manifest, without submitting."""
     return _build(name, step).to_yaml()
+
+
+def _build_cron(name, step, schedule, concurrency_policy="Replace", starting_deadline_seconds=0, timezone=None):
+    """Wrap a single Hera @script function as a scheduled CronWorkflow with platform defaults.
+
+    Mirrors _build, but the job runs on a schedule instead of once. The cron uses a stable
+    name, not generate_name, so creating it again targets the same cron object. Each tick of
+    the schedule starts a new run under that cron. concurrency_policy and
+    starting_deadline_seconds match the native examples/cronworkflow-example.
+    """
+    with CronWorkflow(
+        name=name,
+        entrypoint="main",
+        namespace=_NAMESPACE,
+        service_account_name=_SERVICE_ACCOUNT,
+        schedule=schedule,
+        concurrency_policy=concurrency_policy,
+        starting_deadline_seconds=starting_deadline_seconds,
+        timezone=timezone,
+    ) as cron_workflow:
+        with Steps(name="main"):
+            step()
+    return cron_workflow
+
+
+def create_cron(cron_workflow):
+    """Create a built CronWorkflow on Pipekit. Returns the PipeRun and prints a run-history link."""
+    pipekit = _service()
+    pipe_run = pipekit.create(cron_workflow, CLUSTER)
+    print(f"created cron {cron_workflow.name} (schedule {cron_workflow.schedule})")
+    print(f"run history: {_UI_URL}/pipes/{pipe_run.pipe_uuid}")
+    return pipe_run
+
+
+def cron(name, step, schedule, concurrency_policy="Replace", starting_deadline_seconds=0, timezone=None):
+    """Schedule a @script function to run on a recurring basis, via Pipekit.
+
+    schedule is a standard cron expression, for example "0 6 * * *" for 06:00 every day. The
+    job runs with the same platform defaults as run(): the data image, resources, namespace,
+    and service account. Returns the PipeRun for the created cron and prints a link to its run
+    history in the UI. Manage the cron after creation (suspend, resume, delete, trigger) from
+    the Pipekit CLI or UI; the SDK creates cron workflows but does not manage their lifecycle.
+    """
+    return create_cron(_build_cron(name, step, schedule, concurrency_policy, starting_deadline_seconds, timezone))
+
+
+def cron_to_yaml(name, step, schedule, concurrency_policy="Replace", starting_deadline_seconds=0, timezone=None):
+    """Return the CronWorkflow as a committable manifest, without creating it."""
+    return _build_cron(name, step, schedule, concurrency_policy, starting_deadline_seconds, timezone).to_yaml()
 
 
 def logs(result, follow=False, timeout_seconds=3900):

--- a/examples/hera-notebook-forecast/dataplatform/__init__.py
+++ b/examples/hera-notebook-forecast/dataplatform/__init__.py
@@ -17,7 +17,9 @@ Hera ``@script`` function and submits it:
 ``run``/``submit`` send the workflow to Pipekit and print a link to watch it live.
 ``logs(result)`` prints a log snapshot. ``to_yaml`` returns the same workflow as a
 manifest you can commit to git (the GitOps path). ``cron`` schedules the same job to
-run on a recurring basis.
+run on a recurring basis; re-running it with the same name updates the existing cron.
+``suspend_cron``, ``resume_cron``, ``delete_cron``, and ``get_cron`` manage that cron
+after you create it. They need pipekit-sdk 2.1.2 or newer.
 
 These defaults target the Pipekit free trial cluster: namespace ``argo``, service
 account ``argo-workflow`` (set explicitly, since the controller default is ``argo``
@@ -127,26 +129,45 @@ def _build_cron(name, step, schedule, concurrency_policy="Replace", starting_dea
     return cron_workflow
 
 
-def create_cron(cron_workflow):
-    """Create a built CronWorkflow on Pipekit. Returns the PipeRun and prints a run-history link.
+def _run_history_link(pipekit, name):
+    """Return the UI run-history URL for a cron's pipe, or None if no pipe matches.
 
-    The SDK only creates crons, it cannot update them. Creating one whose name already exists
-    on the cluster fails. We turn that one API error into a clear message that says how to
-    recover, since an analyst re-running the cell is the common way to hit it.
+    The create path gets the pipe uuid straight from the API response. The update path
+    does not, so we look the pipe up by name. Pipekit names the pipe after the cron, so a
+    name match points at the same pipe the run history lives under.
+    """
+    cluster = pipekit.get_cluster_by_name(CLUSTER)
+    if cluster is None:
+        return None
+    for pipe in pipekit.list_pipes(cluster.uuid):
+        if pipe.name == name:
+            return f"{_UI_URL}/pipes/{pipe.uuid}"
+    return None
+
+
+def create_cron(cron_workflow):
+    """Create a built CronWorkflow on Pipekit, or update it if the name already exists.
+
+    The call is idempotent on the cron name. An analyst re-running the cell with a changed
+    schedule updates the existing cron instead of failing, so there is no delete-first step.
+    Prints whether it created or updated, plus a link to the cron's run history. Returns the
+    PipeRun on create, or None on update, since the update call returns the cron spec rather
+    than a run.
     """
     pipekit = _service()
+    name = cron_workflow.name
+    schedule = ", ".join(cron_workflow.schedules or [])
     try:
         pipe_run = pipekit.create(cron_workflow, CLUSTER)
     except Exception as err:
-        if "already exists" in str(err):
-            raise RuntimeError(
-                f"a cron named {cron_workflow.name!r} already exists on {CLUSTER}. The SDK creates "
-                "crons but cannot update them. Delete the existing cron from the Pipekit UI or CLI, "
-                "or create this one under a different name, then run this cell again."
-            ) from err
-        raise
-    schedule = ", ".join(cron_workflow.schedules or [])
-    print(f"created cron {cron_workflow.name} (schedule {schedule})")
+        if "already exists" not in str(err):
+            raise
+        pipekit.update_cron(cron_workflow, CLUSTER)
+        print(f"updated cron {name} (schedule {schedule})")
+        if link := _run_history_link(pipekit, name):
+            print(f"run history: {link}")
+        return None
+    print(f"created cron {name} (schedule {schedule})")
     print(f"run history: {_UI_URL}/pipes/{pipe_run.pipe_uuid}")
     return pipe_run
 
@@ -156,9 +177,10 @@ def cron(name, step, schedule, concurrency_policy="Replace", starting_deadline_s
 
     schedule is a standard cron expression, for example "0 6 * * *" for 06:00 every day. The
     job runs with the same platform defaults as run(): the data image, resources, namespace,
-    and service account. Returns the PipeRun for the created cron and prints a link to its run
-    history in the UI. Manage the cron after creation (suspend, resume, delete, trigger) from
-    the Pipekit CLI or UI; the SDK creates cron workflows but does not manage their lifecycle.
+    and service account. The call is idempotent on the name, so re-running it with a changed
+    schedule updates the existing cron. Prints a link to the cron's run history in the UI.
+    Use suspend_cron(name), resume_cron(name), delete_cron(name), and get_cron(name) to
+    manage the cron after you create it.
     """
     return create_cron(_build_cron(name, step, schedule, concurrency_policy, starting_deadline_seconds, timezone))
 
@@ -166,6 +188,46 @@ def cron(name, step, schedule, concurrency_policy="Replace", starting_deadline_s
 def cron_to_yaml(name, step, schedule, concurrency_policy="Replace", starting_deadline_seconds=0, timezone=None):
     """Return the CronWorkflow as a committable manifest, without creating it."""
     return _build_cron(name, step, schedule, concurrency_policy, starting_deadline_seconds, timezone).to_yaml()
+
+
+def suspend_cron(name):
+    """Suspend the cron so it stops scheduling new runs. Returns the updated cron spec.
+
+    Suspend pauses the schedule; runs already started keep going. Call resume_cron(name) to
+    schedule again. name is the cron name you passed to cron(), in the platform namespace.
+    """
+    pipekit = _service()
+    cron_model = pipekit.suspend_cron(CLUSTER, _NAMESPACE, name)
+    print(f"suspended cron {name}")
+    return cron_model
+
+
+def resume_cron(name):
+    """Resume a suspended cron so it schedules runs again. Returns the updated cron spec."""
+    pipekit = _service()
+    cron_model = pipekit.resume_cron(CLUSTER, _NAMESPACE, name)
+    print(f"resumed cron {name}")
+    return cron_model
+
+
+def delete_cron(name):
+    """Delete the cron. Runs it already started are not affected."""
+    pipekit = _service()
+    pipekit.delete_cron(CLUSTER, _NAMESPACE, name)
+    print(f"deleted cron {name}")
+
+
+def get_cron(name):
+    """Fetch the live cron and print its schedule and whether it is suspended.
+
+    Returns the full cron spec, so you can read other fields off the returned object.
+    """
+    pipekit = _service()
+    cron_model = pipekit.get_cron(CLUSTER, _NAMESPACE, name)
+    schedules = ", ".join(cron_model.spec.schedules or [])
+    state = "suspended" if cron_model.spec.suspend else "active"
+    print(f"cron {name}: schedule {schedules}, {state}")
+    return cron_model
 
 
 def logs(result, follow=False, timeout_seconds=3900):


### PR DESCRIPTION
## What

Adds a CronWorkflow demo to the hera notebook forecast example. This is stacked on #42 (log streaming); the base branch is `stream-logs`.

- New `cron_forecast.ipynb`: schedules the existing `forecast_demand` job as a daily `CronWorkflow` (`0 6 * * *`) with one call, then updates, reads, suspends, and resumes it from the SDK. It prints a link to the cron's run history and renders the manifest for the GitOps path.
- New `cron()` and `cron_to_yaml()` helpers in `dataplatform/`, plus `get_cron()`, `suspend_cron()`, `resume_cron()`, and `delete_cron()`. They mirror the existing `run()` and `to_yaml()` and wrap the matching `PipekitService` calls. The schedule setup stays behind one call: `cron("daily-demand-forecast", forecast_demand, schedule="0 6 * * *")`.
- `cron()` is now idempotent on the name. If a cron with that name already exists, it calls `update_cron` instead of failing, so re-running the cell with a changed schedule updates the cron in place. Before, the cell raised an "already exists" error and told the reader to delete the cron first.
- Same free trial cluster defaults as the one-off path: namespace `argo`, service account `argo-workflow`, the pandas image.

The schedule goes into the `schedules` list, not the older singular `schedule` field. Argo Workflows 3.6 deprecated `schedule`, and the free trial cluster CRD now requires `schedules`, so the singular field fails validation with "spec.schedules: Required value".

The lifecycle helpers need pipekit-sdk 2.1.2 or newer. The SDK has no trigger call, so the notebook keeps the CLI command for an on-demand run.

## Why

During a demo, an engineer asked for a CronWorkflow example to go with the notebook forecast. This adds one. It reuses the same job as the one-off run, so the schedule is the only new part. Earlier the SDK could only create a cron; 2.1.2 added the lifecycle methods, so the notebook now manages the cron it creates.

## How to test

From the repo root, inside the dev shell:

- Open `examples/hera-notebook-forecast/cron_forecast.ipynb`, select the `Python (hera-forecast)` kernel, and run the cells top to bottom. The schedule cell creates the cron; later cells update the schedule, read the cron's state, and suspend then resume it.
- Re-run the create cell with a different schedule. It updates the existing cron instead of failing.
- Or render the manifest without creating anything: `cron_to_yaml("daily-demand-forecast", forecast_demand, schedule="0 6 * * *")`. It is the same kind of `CronWorkflow` as the native `examples/cronworkflow-example/workflow.yaml`, with the schedule in the `schedules` list.
- `ruff check examples/hera-notebook-forecast/` passes.

Closes #12544.
